### PR TITLE
modified Publishers for location

### DIFF
--- a/www/js/app/router.js
+++ b/www/js/app/router.js
@@ -189,7 +189,7 @@ define([
       if (!this.publisherCache) {
         map.init(_.bind(function() {
           var sql = new cartodb.SQL({ user: 'vertnet' });
-          var query = "SELECT orgname,icode,sum(count) AS records,count(title) AS resources,citation,contact,count,description,dwca,email,eml,emlrights,pubdate,title,url FROM resource GROUP BY orgname,icode,citation,contact,count,description,dwca,email,eml,emlrights,pubdate,title,url ORDER BY title";
+          var query = "SELECT orgname,icode,Concat(orgcountry,', ', orgstateprovince,', ',orgcity) AS orglocation,sum(count) AS records,count(title) AS resources,citation,contact,count,description,dwca,email,eml,emlrights,pubdate,title,url FROM resource GROUP BY orgname,icode,orgcountry, orgstateprovince, orgcity,citation,contact,count,description,dwca,email,eml,emlrights,pubdate,title,url ORDER BY title";
           sql.execute(query, {})
             .done(_.bind(function(data) {
               this.publisherCache = _.groupBy(data.rows, _.bind(function(row) {
@@ -214,7 +214,7 @@ define([
         return resource.count + memo;
       }, 0);
       var model = new PubModel({orgname: resource.orgname, resources: resCount, 
-        records: recCount, icode: resource.icode}); 
+        records: recCount, icode: resource.icode, orglocation: resource.orglocation}); 
       var resourceList = _.map(resources, function(x) {
         return new ResourceModel(x);
       });

--- a/www/js/app/views/publisher.html
+++ b/www/js/app/views/publisher.html
@@ -24,8 +24,12 @@
     <h1>Publisher <small><%= this.model.get('orgname')%></small></h1>
   </div>
 
-
   <div class="row">
+    <div class="col-lg-10">
+      <span class="lead">
+        Location: <%= this.model.get('orglocation')%>
+      </span>
+    </div>
     <div class="col-lg-10">
       <span class="lead">
         <%= this.model.resources()%> with <%= this.model.records()%> published records. 

--- a/www/js/app/views/publisherrow.html
+++ b/www/js/app/views/publisherrow.html
@@ -20,5 +20,6 @@
 -->
 <td><%= this.model.get('orgname')%></td>
 <td><%= this.model.get('icode')%></td>
+<td><%= this.model.get('orglocation')%></td>
 <td><%= this.model.records()%></td>
 <td><%= this.model.get('resources')%></td>

--- a/www/js/app/views/publishers.html
+++ b/www/js/app/views/publishers.html
@@ -38,6 +38,7 @@
       <tr>
         <th>Publisher</th>        
         <th>Code</th>
+        <th>Location</th>
         <th>Records</th>
         <th>Resources</th>
       </tr>

--- a/www/js/app/views/publishers.js
+++ b/www/js/app/views/publishers.js
@@ -58,7 +58,7 @@ define([
         if (this.pubList.isEmpty()) {
           map.init(_.bind(function() {
             var sql = new cartodb.SQL({ user: 'vertnet' });
-            var query = "SELECT orgname,icode,sum(count) AS records,count(title) AS resources FROM resource GROUP BY orgname, icode ORDER BY orgname";
+            var query = "SELECT orgname,icode,Concat(orgcountry,', ', orgstateprovince,', ',orgcity) AS orglocation, sum(count) AS records,count(title) AS resources FROM resource GROUP BY orgname, icode, orgcountry, orgstateprovince, orgcity ORDER BY orgname";
             sql.execute(query, {})
               .done(_.bind(function(data) {
                 _.each(data.rows, _.bind(function (i) {


### PR DESCRIPTION
Relates to issue: https://github.com/VertNet/webapp/issues/377

Added fields and data to https://vertnet.cartodb.com/tables/resource_staging/.

Added fields and data (to MVZ records only) to https://vertnet.cartodb.com/tables/resource/.

Modified and tested locally.

I should modify concat statement to check for presence of data in orgstateprovince so no random commas.

Maybe publisherrow.html needs a little tweaking on placement of location?

Need to modify meta data pull so that orgcountry, orgstateprovince, orgcity data from resource_staging populates in resource in CartoDB.  But since this is in Gulo repository...need to do under that repository/feature?
