### PR TITLE
Setting results page size to 100 from 20 by popular demand.

### DIFF
--- a/www/js/app/views/search.js
+++ b/www/js/app/views/search.js
@@ -42,7 +42,7 @@ define([
     initialize: function (options, app) {
       this.app = app;
       this.DOWNLOAD_THRES = 1000;
-      this.PAGE_SIZE = 20;
+      this.PAGE_SIZE = 100;
       this.keywords = []; // Search query keywords
       this.terms = {}; // Search query terms
       this.occList = new OccList();


### PR DESCRIPTION
Simple fix in face of user demand. Tests in Berkeley showed no noticible degradation of performance.
