### PR TITLE
changed text from resources to data resources

### DIFF
--- a/www/js/app/views/publishers.js
+++ b/www/js/app/views/publishers.js
@@ -82,7 +82,7 @@ define([
 
       onShow: function() {
         this.$('#reccount').text(util.addCommas(this.pubList.recordCount().toString()) + ' records');
-        this.$('#rescount').text(util.addCommas(this.pubList.resourceCount().toString()) + ' resources');
+        this.$('#rescount').text(util.addCommas(this.pubList.resourceCount().toString()) + ' data resources');
         this.$('#pubcount').text(util.addCommas(this.pubList.publisherCount().toString()) + ' publishers');
       },
 


### PR DESCRIPTION
Per Carla's request. Changed text on publishers page to read as Explore over 10,459,660 records from 126 data resources shared by 55 publishers globally. (Changed resources to read as data resources.)

Refers to issue #419 
