### PR TITLE
add Beta since removing it from logo

### DIFF
--- a/www/js/app/views/footer.html
+++ b/www/js/app/views/footer.html
@@ -21,7 +21,7 @@
 <footer class="footer">
     <div class="container">
 		<p>
-        	VertNet &copy; version 2014-02-12 |
+        	VertNet &copy; version 2014-02-12 Beta |
             <a href="http://nsf.gov" target="_blank"><img src="http://vertnet.org/images/logos/nsf_logo.png" height="20%" width="20%"></a>
 		</p>
     </div>

--- a/www/js/app/views/publishers.html
+++ b/www/js/app/views/publishers.html
@@ -23,7 +23,7 @@
 
   <!-- Page title. -->
   <div class="page-header">
-    <h1>Publishers <small>VertNet</small></h1>
+    <h1>Publishers <small>VertNet Beta</small></h1>
   </div>
   
   <p class="lead">Explore over <span id="reccount" class="text-primary pub-stats"></span> from <span id="rescount" class="text-primary pub-stats"></span> shared by <span id="pubcount" class="text-primary pub-stats"></span> globally.</p>

--- a/www/js/app/views/search.html
+++ b/www/js/app/views/search.html
@@ -21,7 +21,7 @@
 <div id="explore-page-content" class="container">
   <div class="search-spinner"></div>    
   <div class="page-header">
-    <h1>Search <small>VertNet</small></h1>
+    <h1>Search <small>VertNet Beta</small></h1>
   </div>
   <div id="whoops" class="alert fade in">
     <button type="button" class="close" data-dismiss="alert">×</button>


### PR DESCRIPTION
When I updated the navigation in February, I removed Beta from the logo as it caused issues with the navigation wrapping.  Neglected to add Beta back anywhere else.  Added to search page, publishers page and in the footer.  Text changes to HTML only.
