### PR TITLE
changed icode to instutioncode

### DIFF
--- a/www/js/app/views/detail.html
+++ b/www/js/app/views/detail.html
@@ -21,7 +21,7 @@
 <div id="occ-detail-content" class="container">
 
   <div class="page-header">
-    <h1><%= this.model.get('icode') + ' ' + this.model.get('collectioncode') + ' ' + this.model.get('catalognumber')%> <small><%= this.model.getSciName() %> </small></h1>
+    <h1><%= this.model.get('institutioncode') + ' ' + this.model.get('collectioncode') + ' ' + this.model.get('catalognumber')%> <small><%= this.model.getSciName() %> </small></h1>
   </div>
 
   <!--   <div class="row">

--- a/www/js/app/views/detailrow.html
+++ b/www/js/app/views/detailrow.html
@@ -18,7 +18,7 @@
   Note that static assets are sources from www/ which contains full
   sourcecode without minification. 
 -->
-<td><%= this.model.get('icode') + ' ' + this.model.get('collectioncode') + ' ' + this.model.get('catalognumber')%></td>
+<td><%= this.model.get('institutioncode') + ' ' + this.model.get('collectioncode') + ' ' + this.model.get('catalognumber')%></td>
 <td><%= this.model.get('class') + ': ' +  this.model.get('scientificname')%></td>
 <td><% var loc = this.model.getLocation() %> <%= loc %></td>
 <td><% var year = this.model.getYear() %> <%= year %></td>


### PR DESCRIPTION
Changed html display in detailrow and detail to display institutioncode instead of icode.  Search and data submit will still use functionality of icode.  Resolves issue identified in #423.  Tucos comment on #423 more directly applies to #361.

This fix does not resolve issue identified in #361. #361 would only be resolved to change the icode data in cartodb resource_staging for insitutions with a non-standard institutionCode for certain collections.  This fix however does not require a code change.  

Display alone may satisfy Carla's reported issue.  If so we could remove issue #361.  If not and being able to search for MVZObs as described in #361, then we'll need to modify the data in cartodb.
