### PR TITLE
Sets 10,000 as the default value of the App Engine search parameter...

### DIFF
--- a/vertnet/service/search.py
+++ b/vertnet/service/search.py
@@ -54,9 +54,12 @@ def query(q, limit, index_name='dwc', sort=None, curs=search.Cursor()):
             sort_options=sort_options)
             #returned_fields=['record', 'location'])        
     else:
+        # Always use 10,000 as the value for number_found_accuracy. Based on
+        # extensive testing, using this maximum-allowed value results in the best
+        # count accuracy and incurs only a minor performance penalty.
         options = search.QueryOptions(
             limit=limit,
-            number_found_accuracy=limit+1,
+            number_found_accuracy=10000,
             cursor=curs) #,
             #returned_fields=['record', 'location'])        
 


### PR DESCRIPTION
..."number_found_accuracy" for searches from the VertNet portal, for the same reasons we now use this as the default for searches from the Web API.

I have tested this change to confirm that it will apply to searches through both the "simple" and "advanced" search interfaces in the portal.

However, it does _not_ apply to searches that include a sort (the API does not do this, either).  This is because "number_found_accuracy" was explicitly _not_ getting set for searches with a sort, and I am assuming there was a reason for that (there are no comments in the code to explain it).
