### PR TITLE
Applied the 100th-record line break fix to the download API.

### DIFF
--- a/vertnet/service/download.py
+++ b/vertnet/service/download.py
@@ -55,7 +55,7 @@ class WriteHandler(webapp2.RequestHandler):
                     if not curs:
                         params = dict(query=q, type='download', count=count, downloader=email, latlon=latlon)
                         taskqueue.add(url='/apitracker', params=params, queue_name="apitracker") 
-                    chunk = _get_tsv_chunk(records)
+                    chunk = '%s\n' % _get_tsv_chunk(records)
                     f.write(chunk) 
                     f.close(finalize=False)     
                     success = True


### PR DESCRIPTION
This fixed all missing record problems for all queries in the set of 25 queries I was using to test the download API's behavior.
