### PR TITLE
Set a hard fail limit of 6 days for the download file writing task queue.

### DIFF
--- a/queue.yaml
+++ b/queue.yaml
@@ -26,3 +26,5 @@ queue:
   rate: 35/s
 - name: downloadwrite
   rate: 35/s
+  retry_parameters:
+    task_age_limit: 6d


### PR DESCRIPTION
This does not directly fix the "hung" download request problem, but it should at least ensure that the task queue does not accumulate stuck download requests indefinitely.  If we think 6 days is too long or not long enough, we can adjust accordingly.
