### PR TITLE
Set a hard fail limit of 6 days for the download file writing task queue.

### DIFF
--- a/queue.yaml
+++ b/queue.yaml
@@ -24,3 +24,5 @@ queue:
   rate: 35/s
 - name: downloadwrite
   rate: 35/s
+  retry_parameters:
+    task_age_limit: 6d


### PR DESCRIPTION
Same explanation and rationale as for the previously submitted pull request for the master branch.
