### PR TITLE
Modified calculations for Records Searched

### DIFF
--- a/www/js/app/views/stats.html
+++ b/www/js/app/views/stats.html
@@ -5,7 +5,7 @@
     <table><tr><td style="width: 50%;">
     <div id="numeric-stats" class="stat-panel" style="width: 500px; height: 300px; display:table-cell; vertical-align:middle"><table>
     <tr><td>Number of queries: </td><td> <div id="queries"></div> </td></tr>
-    <tr><td>Number of records queried: </td><td><div id="qrecords"></td></tr>
+    <tr><td>Number of records pulled to the screen: &nbsp &nbsp</td><td><div id="qrecords"></td></tr>
     <tr><td>Number of downloads: </td><td><div id="downloads"></td></tr>
     <tr><td>Number of records downloaded: </td><td><div id="drecords"></td></tr>
     </table></div>


### PR DESCRIPTION
Changes:
- Records Searched changed for Records Pulled to the Screen
- Calculation changed from summing the values in "count" field
  (way too biased) to summing the counts for individual resources
  in "results_by_resource"
- Added some spaces between longest string and values in table
- Changed start date to Apr 1st, to ensure consistency of numbers
