### PR TITLE
edited advanced search form for spacing

### DIFF
--- a/www/css/vertnet.css
+++ b/www/css/vertnet.css
@@ -8,10 +8,10 @@
 .vncheckbox {
        position: relative;
        min-height: 20px;
-       padding-left: 15px;
-       margin-top: 10px;
-       margin-bottom: 10px;
-       vertical-align: middle
+       padding-left: 20px;
+       margin-top: 7px;
+       margin-bottom: 0px;
+       vertical-align: top
 }
 
 .col-md-0 {
@@ -20,6 +20,15 @@
        margin-top: 10px;
        padding-right: -30px;
        padding-left: -25px;
+       float: left;
+}
+
+.vn-col-md-2 {
+       position: relative;
+       min-height: 1px;
+       padding-right: 15px;
+       padding-left: 15px;
+	   /*width: 16.666666666666664%;*/
        float: left;
 }
 
@@ -517,5 +526,16 @@ h7 small, .h7 small {
 	font-weight: normal;
 	line-height: 1;
 	color: #999
+}
+VNlegend {
+	display: block;
+	width: 100%;
+	padding: 0;
+	margin-bottom: 5px;
+	font-size: 20px;
+	/*line-height: inherit;*/
+	color: #333;
+	border: 0;
+	border-bottom: 1px solid #e5e5e5
 }
 

--- a/www/js/app/views/search.html
+++ b/www/js/app/views/search.html
@@ -40,7 +40,7 @@
     </div>            
     <div id="advanced-search-form">
       <button id="close-advanced-search" type="button" class="close" data-dismiss="alert">×</button>
-      <legend>Find records with...</legend>
+      <VNlegend>Find records with...</VNlegend>
 <!--
       Find occurrences with...<p>
 -->
@@ -50,21 +50,27 @@
           <div class="form-group">
             <label class="col-lg-2 control-label">These filters</label>
             <div class="vncheckbox">
-              <label class="col-md-2">
+              <label class="vn-col-md-2">
                 <input id="fossil" type="checkbox"> Is fossil
               </label>
-              <label class="col-md-2">
+              <label class="vn-col-md-2">
                 <input id="tissue" type="checkbox"> Has tissues
               </label>
-              <label class="col-md-2">
+              <label class="vn-col-md-2">
                 <input id="media" type="checkbox"> Has media
               </label>
-              <label class="col-md-2">
+              <label class="vn-col-md-2">
                 <input id="hastypestatus" type="checkbox"> Has type status
               </label>
+              <label class="vn-col-md-2">
+                <input id="mappable" type="checkbox"> Is mappable
+              </label>
+              <label class="vn-col-md-2">
+                <input id="spatialfilter" type="checkbox"> In circle on map
+              </label>                
             </div>
           </div>
-          <div class="form-group">
+<!--          <div class="form-group">
             <label class="col-lg-2 control-label">&nbsp;&nbsp;&nbsp;</label>
             <div class="vncheckbox">
               <label class="col-md-2">
@@ -75,7 +81,7 @@
               </label>                                          
             </div>
           </div>
-
+ -->
         </div>
 
         <div id="spatialsearch">
@@ -205,7 +211,6 @@
           </div>
         </div>
 
-        <div class="form-group">
  <!--         <label class="col-lg-2 control-label">Sorted by</label>
           <div class="col-lg-10">
             <select class="form-control" id="sort">
@@ -221,15 +226,15 @@
               <option>Year</option>
               <option>RecordedBy</option>
             </select>
-          </div> -->
-        </div>
-        <div class="form-group">
+          </div> 
+        </div>-->
+        <!--<div class="form-group">
           <div class="col-lg-10">
             <button id="search-button-advanced" type="button" class="btn btn-large btn-primary">
               <span class="glyphicon glyphicon-search icon-white"></span>
             </button>
           </div>
-        </div>
+        </div> -->
       </form>
       <div class="spacer"></div>
     </div>


### PR DESCRIPTION
Edited css to reduce spacing in header row (Find records with...).

Brought filter checkboxes to one row.

Removed search button from within advanced search window as the search button outside the window to the top right issues the same action (as well as does hitting enter on the keyboard)

Now able to see the pro tip pop in after a search completes (or if the pro tip has been dismissed) the first row of the record set.

Can review changes at http://129.237.201.29:8080/search?advanced=1
