### PR TITLE
added links and info icons for end user help

### DIFF
--- a/www/css/vertnet.css
+++ b/www/css/vertnet.css
@@ -539,3 +539,20 @@ VNlegend {
 	border-bottom: 1px solid #e5e5e5
 }
 
+.infotip {
+	color:#0088cc;
+}
+
+.infotipDisplay {
+	text-align:left !important;
+	font-weight:lighter !important;
+	width: 0;
+	height: 0;
+	margin-top: -50px;
+	border-top: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-bottom: 0 dotted;
+	border-left: 4px solid transparent;
+	content: ""
+}
+

--- a/www/js/app/models/publishers.js
+++ b/www/js/app/models/publishers.js
@@ -46,6 +46,16 @@ define([
             return memo;
           }
         }, 0);
+      },
+	  
+      collectionCount: function() {
+        return this.reduce(function(memo, model) {
+          if (model.get('collections') > 0) {
+            return model.get('collections') + memo;
+          } else {
+            return memo;
+          }
+        }, 0);
       }
     });
 });

--- a/www/js/app/views/detail.html
+++ b/www/js/app/views/detail.html
@@ -397,14 +397,13 @@
     
     <!-- Quality tab -->
     <div id="quality" class="tab-pane fade">
-    <p>
     <!-- <p class="lead">Quality Report</p> -->
-    <blockquote id="quality-warning">
-    </blockquote>
+    <p></p>
+    <blockquote id="quality-warning"></blockquote>
     <table class="table table-striped">
         <thead>
           <tr>
-            <th>Data completeness</th>
+            <th>Data completeness&nbsp;<a id="show-completeness-tip" href="http://www.vertnet.org/resources/spatialqualitytabguide.html#completeness" target="_blank"><span id="completeness-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a></th>
             <th></th>
             <th></th>
           </tr>
@@ -419,7 +418,7 @@
         </tbody>
         <thead>
           <tr>
-            <th>Data inconsistencies</th>
+            <th>Data inconsistencies&nbsp;<a id="show-inconsistencies-tip" href="http://www.vertnet.org/resources/spatialqualitytabguide.html#inconsistencies" target="_blank"><span id="inconsistencies-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a></th>
             <th></th>
             <th></th>
           </tr>
@@ -432,7 +431,7 @@
         </tbody>
         <thead>
           <tr>
-            <th>Data Errors</th>
+            <th>Data Errors&nbsp;<a id="show-error-tip" href="http://www.vertnet.org/resources/spatialqualitytabguide.html#errors" target="_blank"><span id="error-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a></th>
             <th></th>
             <th></th>
           </tr>
@@ -446,7 +445,8 @@
         </tbody>
         <tfoot>
           <tr>
-            <td><small><sup>1</sup><i>Assessed with <a href="http://www.mol.org/" target="_blank">Map Of Life</a> validation tools</i></small></td>
+            <td><small><sup>1</sup><i>Assessed with <a href="http://www.mol.org/" target="_blank">Map Of Life</a> validation tools</i></small></td><td>&nbsp;</td><td align="right"><small>Questions? Read our <a href="http://vertnet.org/resources/spatialqualitytabguide.html" title="Link to VN Portal Spatial Quality Tab Guide" target="_blank">Spatial Quality Tab Guide</a>.</small>
+</td>
           </tr>
         </tfoot>
       </table> 

--- a/www/js/app/views/detail.js
+++ b/www/js/app/views/detail.js
@@ -190,6 +190,45 @@ define([
           });
           
         }, this));
+		
+		//Tooltips
+		  this.$('#show-completeness-tip').tooltip({
+			  placement: 'top',
+			  html: 'true',
+			  title: 'Data completeness assesses the presence and absence of certain fields within a record. The assessments simply reveal if a given field is present or not, or, in some cases, if the field contains a potentially correct value or not. Read more...',
+			  container: '#completeness-tip'
+			});
+		  this.$('#completeness-tip').mouseover(_.bind(function(e) {
+			this.$('#show-completeness-tip').tooltip('show');
+		  }, this)).mouseout(_.bind(function(e) {
+			this.$('#show-completeness-tip').tooltip('hide');
+		  }, this));
+		  
+		  this.$('#show-inconsistencies-tip').tooltip({
+			  placement: 'top',
+			  html: 'true',
+			  title: 'The tests in this section seek to identify mismatches between different sources of data. All of the assessments are performed with the Map Of Life quality validation tool.  It is important to note that an inconsistency does not necessarily equate with a mistake.  The tool is only designed to flag potential issues for the user of the data to review. Read more...',
+			  container: '#inconsistencies-tip'
+			});
+		  this.$('#inconsistencies-tip').mouseover(_.bind(function(e) {
+			this.$('#show-inconsistencies-tip').tooltip('show');
+		  }, this)).mouseout(_.bind(function(e) {
+			this.$('#show-inconsistencies-tip').tooltip('hide');
+		  }, this));		
+
+		  this.$('#show-error-tip').tooltip({
+			  placement: 'top',
+			  html: 'true',
+			  title: 'The tests in this section seek to identify data errors within specific fields of a record.  Three of these assessments are performed with the Map Of Life quality validation tool. Read more...',
+			  container: '#error-tip'
+			});
+		  this.$('#error-tip').mouseover(_.bind(function(e) {
+			this.$('#show-error-tip').tooltip('show');
+		  }, this)).mouseout(_.bind(function(e) {
+			this.$('#show-error-tip').tooltip('hide');
+		  }, this));		
+		  	
+		
 
         // Handler for click.
         this.$('#submit-issue-btn').click(_.bind(function(e) {

--- a/www/js/app/views/footer.html
+++ b/www/js/app/views/footer.html
@@ -21,7 +21,7 @@
 <footer class="footer">
     <div class="container">
 		<p>
-        	VertNet &copy; version 2014-08-28T10:19:00 |
+        	VertNet &copy; version 2014-09-12T13:35:00 |
             <a href="http://nsf.gov" target="_blank"><img src="http://vertnet.org/images/logos/nsf_logo.png" height="20%" width="20%"></a>
 		</p>
     </div>

--- a/www/js/app/views/header.html
+++ b/www/js/app/views/header.html
@@ -110,7 +110,7 @@
                     </li>
                   </ul>
                 </li>
-			    <li class-""><a href="http://www.vertnet.org/resources/help.html">&nbsp;<small><b class="glyphicon glyphicon-question-sign"></b></small></a></li>
+			    <li class-""><a href="http://www.vertnet.org/resources/help.html#t-tab2" target="_blank">&nbsp;<small><b class="glyphicon glyphicon-question-sign"></b></small></a></li>
               </ul>
     </ul>
     <ul class="nav navbar-nav navbar-right">

--- a/www/js/app/views/publishers.html
+++ b/www/js/app/views/publishers.html
@@ -26,7 +26,7 @@
     <h1>Publishers <small>VertNet</small></h1>
   </div>
   <!--<p class="lead">Help us create a plan for VertNet's future. Take our <a href="http://www.vertnet.org/feedback/sustainabilitysurvey.html" target="_blank" title="VertNet Sustainability Survey">Sustainability Survey</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small>.</p> -->
-  <p class="lead">Explore over <span id="reccount" class="text-primary pub-stats"></span> from <span id="rescount" class="text-primary pub-stats"></span> shared by <span id="pubcount" class="text-primary pub-stats"></span> globally.</p>
+  <p class="lead">Explore over <span id="reccount" class="text-primary pub-stats"></span> from <span id="rescount" class="text-primary pub-stats"></span>, containing <span id="colcount" class="text-primary pub-stats"></span>, shared by <span id="pubcount" class="text-primary pub-stats"></span> globally.</p>
 
   <div id="click-row-tip" class="alert alert-success">
     <button type="button" class="close" data-dismiss="alert">×</button>

--- a/www/js/app/views/publishers.js
+++ b/www/js/app/views/publishers.js
@@ -58,7 +58,7 @@ define([
         if (this.pubList.isEmpty()) {
           map.init(_.bind(function() {
             var sql = new cartodb.SQL({ user: 'vertnet' });
-            var query = "SELECT orgname,icode,sum(count) AS records,count(title) AS resources FROM resource WHERE ipt=True and networks LIKE '%VertNet%' GROUP BY orgname, icode ORDER BY orgname";
+            var query = "SELECT orgname,icode,sum(count) AS records,sum(collectioncount) AS collections,count(title) AS resources FROM resource WHERE ipt=True and networks LIKE '%VertNet%' GROUP BY orgname, icode ORDER BY orgname";
             sql.execute(query, {})
               .done(_.bind(function(data) {
                 _.each(data.rows, _.bind(function (i) {
@@ -84,6 +84,7 @@ define([
         this.$('#reccount').text(util.addCommas(this.pubList.recordCount().toString()) + ' records');
         this.$('#rescount').text(util.addCommas(this.pubList.resourceCount().toString()) + ' data resources');
         this.$('#pubcount').text(util.addCommas(this.pubList.publisherCount().toString()) + ' publishers');
+        this.$('#colcount').text(util.addCommas(this.pubList.collectionCount().toString()) + ' collections');
       },
 
       _clickHandler: function(e) {

--- a/www/js/app/views/search.html
+++ b/www/js/app/views/search.html
@@ -23,8 +23,8 @@
   <div class="page-header">
     <h1>Search <small>VertNet</small></h1>
   </div>
-<!--    <p class="lead">Help us create a plan for VertNet's future. Take our <a href="http://www.vertnet.org/feedback/sustainabilitysurvey.html" target="_blank" title="VertNet Sustainability Survey">Sustainability Survey</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small>.</p>
- -->  <div id="whoops" class="alert fade in">
+    <p><a href="http://vertnet.org/resources/help.html#t-tab2" title="Link to VN Portal Help page" target="_blank"> Need Help?</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small></p>
+  <div id="whoops" class="alert fade in">
     <button type="button" class="close" data-dismiss="alert">×</button>
     Search is a little slow right now. Automatically retrying ...
   </div>


### PR DESCRIPTION
Please review and test the following changes.  Wait for @robgur review before merging and pushing live.

Added Help link to search page: http://129.237.201.29:8080/search

Added info icons and associated tooltip javascript and css for Spatial Quality tab in detail. Also added full link to Spatial Quality Tab guide under results table: http://129.237.201.29:8080/o/western-new-mexico-university/wnmu-fish-collection-arctos?id=c490c59b-867d-4b5f-b5be-cbb4bd931666#

Added collections language to publishers page per Rob's request: http://129.237.201.29:8080/publishers

Modified header menu so that ? icon goes to portal help tab (in a new window since users are likely to want to be able to click between both the portal and the help if they need help).

Modified footer for change date/time.

Also added collections language to third slide on carousel at http://www.vertnet.org (not part of this pull)
