### PR TITLE
Added route for GitHub repo name checker: /service/repochecker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ storage/
 www-built/
 data/
 cdbkey.txt
+ghkey.txt
 *.pyc
 *.sublime-*
 *.*~

--- a/app.yaml
+++ b/app.yaml
@@ -79,6 +79,9 @@ handlers:
 - url: /service/stats.*
   script: vertnet.service.stats.main
 
+- url: /service/repochecker.*
+  script: vertnet.service.repochecker.main
+
 # CRON tasks
 
 - url: /tasks/daily_portal_stats.*

--- a/vertnet/service/repochecker.py
+++ b/vertnet/service/repochecker.py
@@ -28,7 +28,7 @@ headers = {
 
 def get_all_repos():
     """Extract a list of all github_orgnames and github_reponames from CartoDB."""
-    query = "select github_orgname, github_reponame from resource_staging where ipt is true and networks like '%VertNet%' limit 5;"
+    query = "select github_orgname, github_reponame from resource_staging where ipt is true and networks like '%VertNet%';"
     vals = {
         'api_key': cdb_key,
         'q': query

--- a/vertnet/service/repochecker.py
+++ b/vertnet/service/repochecker.py
@@ -1,0 +1,128 @@
+import os
+import json
+import logging
+import urllib
+import urllib2
+
+__author__ = '@jotegui'
+
+
+# Get API key from file
+def apikey(serv):
+    """Return credentials file as a JSON object."""
+    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), '{0}key.txt'.format(serv))
+    key = open(path, "r").read().rstrip()
+    logging.info("KEY %s" % key)
+    return key
+cdb_key=apikey('cdb')
+gh_key=apikey('gh')
+
+ghb_url = 'https://api.github.com'
+cdb_url = "https://vertnet.cartodb.com/api/v2/sql"
+testing = False
+headers = {
+    'User-Agent': 'VertNet',  # Authenticate as VertNet
+    'Accept': 'application/vnd.github.v3+json',  # Require version 3 of the API (for stability)
+    'Authorization': 'token {0}'.format(gh_key)  # Provide the API key
+}
+
+def get_all_repos():
+    """Extract a list of all github_orgnames and github_reponames from CartoDB."""
+    query = "select github_orgname, github_reponame from resource_staging where ipt is true and networks like '%VertNet%' limit 5;"
+    vals = {
+        'api_key': cdb_key,
+        'q': query
+    }
+    data = urllib.urlencode(vals)
+    req = urllib2.Request(cdb_url, data)
+    
+    try:
+        res = urllib2.urlopen(req)
+    except:
+        logging.error("Something went wrong querying CartoDB")
+        return None
+
+    all_repos = json.loads(res.read())['rows']
+    logging.info("Got {0} repos currently in CartoDB".format(len(all_repos)))
+    return all_repos
+
+
+
+def list_org(org):
+    """Get a list of the repositories associated with an organization in GitHub."""
+    req_url = '/'.join([ghb_url, 'orgs', org, 'repos'])
+
+    req = urllib2.Request(req_url)
+    for key in headers:
+        req.add_header(key, headers[key])
+
+    try:
+        res = urllib2.urlopen(req)
+    except:
+        logging.error("Something went wrong trying to list the repos of {0}".format(org))
+        logging.error(req.get_full_url())
+        return None
+
+    content = json.loads(res.read())
+    logging.info("Got repos for {0}".format(org))
+    return [x['name'] for x in content]
+    
+
+
+def check_failed_repos():
+    """Check repository name consistency between CartoDB and GitHub."""
+    failed_repos = []
+    all_repos = get_all_repos()
+    
+    for repo in all_repos:
+        orgname = repo['github_orgname']
+        reponame = repo['github_reponame']
+        
+        if orgname is None or reponame is None:
+            failed_repos.append(repo)
+            continue
+        
+        repo_list = list_org(orgname)
+
+        if repo_list is not None:
+            if reponame not in repo_list:
+                failed_repos.append(repo)
+        else:
+            failed_repos.append(repo)
+    
+    return failed_repos
+
+
+def main(environ, start_response):
+    """Main process."""
+    
+    # Starting response
+    status = 200
+    headers = {}
+    logging.info("Starting response")
+    start_response(status, headers)
+    logging.info("Response started")
+
+
+    logging.info("Checking consistency of repository names between CartoDB and GitHub.")
+    failed_repos = check_failed_repos()
+    
+    res = {
+        'result': None,
+        'failed_repos': []
+    }
+
+    if len(failed_repos) > 0:
+        res['failed_repos'] = failed_repos
+        res['result'] = "error"
+        logging.error("there were issues in the repository name matching.")
+    
+    else:
+        res['result'] = "success"
+        logging.info("the consistency check could not find any issue.")
+    
+    return json.dumps(res)
+
+if __name__ == "__main__":
+    
+    main()


### PR DESCRIPTION
Implemented GitHub repo name checking script in a new VertNet service.

**Deployment instructions:**

For security reasons, GitHub API key is not included in the commit. Add before deploying as follows:

1. Save VertNet's GitHub API key as plain text in file /vertnet/service/ghkey.txt (the same as cdbkey.txt)
2. Then, deploy

**Access instructions**

The service is available via the route /service/repochecker. When deployed, this will be accessible from http://portal.vertnet.org/service/repochecker

**Return**

Script returns json object with 2 elements:

* result: either "success" or "error". "success" if there is no name mismatch, "error" if there is name mismatch
* failed_repos: array. Empty if there is no name mismatch, list of problematic values if there is name mismatch.