### PR TITLE
Fix #542

### DIFF
--- a/vertnet/service/tracker.py
+++ b/vertnet/service/tracker.py
@@ -37,7 +37,7 @@ class TrackerHandler(webapp2.RequestHandler):
             res_counts = self.request.get('res_counts')
         except:
             res_counts = {}
-        log_sql = """INSERT INTO query_log(client,query,error,type,count,downloader,download,lat,lon, results_by_resource) VALUES ('%s','%s','%s','%s',%s,'%s','%s',%s,%s,'%s');update query_log set the_geom = CDB_LatLng(lat,lon)"""
+        log_sql = """INSERT INTO query_log_master(client,query,error,type,count,downloader,download,lat,lon, results_by_resource) VALUES ('%s','%s','%s','%s',%s,'%s','%s',%s,%s,'%s');update query_log_master set the_geom = CDB_LatLng(lat,lon)"""
         log_sql = log_sql % (CLIENT, query, error, type, count, downloader,download,lat,lon,res_counts)
         
         rpc = urlfetch.create_rpc()


### PR DESCRIPTION
In the 'master' branch, only 'vertnet/service/tracker.py' shows references to query_log. Changed to query_log_master