### PR TITLE
changed storage url base

### DIFF
--- a/vertnet/service/download.py
+++ b/vertnet/service/download.py
@@ -87,7 +87,7 @@ class WriteHandler(webapp2.RequestHandler):
                 mail.send_mail(sender="VertNet Downloads <vertnetinfo@vertnet.org>", 
                     to=email, subject="Your VertNet download is ready!",
                     body="""
-You can download "%s" here within the next 24 hours: https://storage.cloud.google.com/vn-downloads2/%s
+You can download "%s" here within the next 24 hours: https://storage.googleapis.com/vn-downloads2/%s
 """ % (name, filename.split('/')[-1]))
 
 class DownloadHandler(webapp2.RequestHandler):


### PR DESCRIPTION
Fixes issue #551 

Changes storage base URL 

from storage.cloud.google.com

to storage.googleapis.com