### PR TITLE
Round 3 edits, help text, sizing, scroll to results

### DIFF
--- a/www/css/vertnet.css
+++ b/www/css/vertnet.css
@@ -33,7 +33,7 @@
        min-height: 1px;
        padding-right: 15px;
        padding-left: 15px;
-	   width: 15.75%;
+	   width: 15.7%;
 /*	   width: 16.666666666666664%;*/
        float: left;
 }
@@ -290,7 +290,7 @@ input.span2.search {
 
 #occ-detail-map {
   border: 1px solid grey;
-  height: 200px;
+  height: 300px;
   width: 100%;
   margin-bottom: 30px;
   margin-top: 20px;

--- a/www/js/app/views/detail.html
+++ b/www/js/app/views/detail.html
@@ -400,7 +400,7 @@
       <dd><% if (this.model.get('emlrights')) { %>
               <%= this.model.getRights() %>
             <% } else { %>
-              Please contact the <a href="<%= this.model.get('source_url') %>">data publisher</a> for details concerning the use of these data.
+              Please contact the <a target="_blank" href="<%= this.model.get('source_url') %>">data publisher</a> for details concerning the use of these data.
             <% } %></dd>
       <br>
       <dt>Citation</dt>
@@ -414,14 +414,14 @@
       <br>
       <dt>Contact</dt>
       <dd>
-        <%= this.model.get('contact') %> <<a href="mailto:<%= this.model.get('email') %>"><%= this.model.get('email') %></a>>
+        <%= this.model.get('contact') %> <<a target="_blank" href="mailto:<%= this.model.get('email') %>"><%= this.model.get('email') %></a>>
       </dd>
       <br>
       <dt>Published</dt>
       <dd><%= this.model.get('pubdate') %></dd>
       <br>
       <dt>Source URL</dt>
-      <dd><a href="<%= this.model.get('source_url') %>"><%= this.model.get('source_url') %></a></dd>
+      <dd><a target="_blank" href="<%= this.model.get('source_url') %>"><%= this.model.get('source_url') %></a></dd>
     </dl>
   </div>
     

--- a/www/js/app/views/search.html
+++ b/www/js/app/views/search.html
@@ -23,7 +23,7 @@
   <div class="page-header">
     <h1>Search <small>VertNet</small></h1>
   </div>
-    <p><a href="http://vertnet.org/resources/help.html#t-tab2" title="Link to VN Portal Help page" target="_blank"> Need Help?</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small>&nbsp;<a href="http://vertnet.org/publishers" title="Link to VN Portal Publishers" target="_blank"> Institution Codes</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small></p>
+    <p><a href="http://vertnet.org/resources/help.html#t-tab2" title="Link to VN Portal Help page" target="_blank"> Need Help?</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small>&nbsp;<a href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" title="Link to VN Portal Advanced Search Guide" target="_blank"> Advanced Search Guide</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small>&nbsp;<a href="http://vertnet.org/publishers" title="Link to VN Portal Publishers" target="_blank"> Institution Codes</a>&nbsp;<small><b class="glyphicon glyphicon-share-alt"></b></small></p>
   <div id="whoops" class="alert fade in">
     <button type="button" class="close" data-dismiss="alert">×</button>
     Search is a little slow right now. Automatically retrying ...
@@ -45,7 +45,7 @@
       <form class="form-horizontal" role="form">
         <div id="filters">
           <div class="form-group">
-            <label class="col-lg-2 control-label"><a id="show-thesefilters-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="thesefilters-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>These filters</label>
+            <label class="col-lg-2 control-label"><!--<a id="show-thesefilters-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="thesefilters-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a> --> &nbsp; These filters</label>
             <div class="vncheckbox">
               <label class="vn-col-md-2-ckbx control-label">
                Is fossil <input id="fossil" type="checkbox"> 
@@ -84,35 +84,35 @@
         </div>
 
         <div class="form-group">
-          <label class="col-lg-2 control-label"><a id="show-allTheseWords-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="allTheseWords-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>All these words</label>
+          <label class="col-lg-2 control-label"><!--<a id="show-allTheseWords-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="allTheseWords-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a> --> &nbsp; All these words</label>
           <div class="col-lg-10">
-            <input type="text" class="form-control" id="allwords" placeholder="mvz grinnell">
+            <input type="text" class="form-control" id="allwords" placeholder="Identify records containing all of the words submitted. For exact phrase, quotation marks are required.">
           </div>
         </div>
 
-        <div class="form-group">
+        <!--<div class="form-group">
           <label class="col-lg-2 control-label"><a id="show-exactPhrase-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="exactPhrase-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Exact phrase</label>
-          <div class="col-lg-10">
+          <div class="col-lg-9">
             <input type="text" class="form-control" id="exactphrase" placeholder='"butorides virescens"'>
           </div>
-        </div>                
+        </div> -->                
 
         <div class="form-group">
-          <label class="col-lg-2 control-label"><a id="show-anyWords-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="anyWords-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Any of these words</label>
+          <label class="col-lg-2 control-label"><!--<a id="show-anyWords-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="anyWords-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a> --> &nbsp; Any of these words</label>
           <div class="col-lg-10">
-            <input type="text" class="form-control" id="anywords" placeholder='tissue OR preserved'>
+            <input type="text" class="form-control" id="anywords" placeholder='Identify all records that contain at least one of the words submitted. Operators OR and AND can help to focus queries.'>
           </div>
         </div>
 
         <div class="form-group">
-          <label class="col-lg-2 control-label"><a id="show-noneWords-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="noneWords-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>None of these words</label>
+          <label class="col-lg-2 control-label"><!--<a id="show-noneWords-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="noneWords-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a> --> &nbsp; None of these words</label>
           <div class="col-lg-10">
-            <input type="text" class="form-control" id="nonewords" placeholder='NOT bufo NOT california'>
+            <input type="text" class="form-control" id="nonewords" placeholder='Exclude records by including NOT along with the word to be excluded.'>
           </div>
         </div>
         
         <div class="form-group">
-          <label class="col-lg-2 control-label"><a id="show-recordType-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="recordType-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Record type</label>
+          <label class="col-lg-2 control-label"><!--<a id="show-recordType-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="recordType-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a> --> &nbsp; Record type</label>
           <div class="col-lg-10">
             <select class="form-control" id="recordtype">
               <option value="Any type">Any type</option>
@@ -124,7 +124,7 @@
         </div>
         
              <div class="form-group">
-            <label class="col-lg-2 control-label"><a id="show-instCode-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="instCode-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Institution</label>
+            <label class="col-lg-2 control-label"><!--<a id="show-instCode-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="instCode-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a> --> &nbsp; Institution Code</label>
               <div class="col-lg-10">
             <select class="form-control" id="inst-dropdown">             
             </select>
@@ -133,7 +133,7 @@
 
         <div id="dwcterm">
           <div class="form-group">
-            <label class="col-lg-2 control-label"><a id="show-dcTerms-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="dcTerms-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Darwin Core terms</label>         
+            <label class="col-lg-2 control-label"><!--<a id="show-dcTerms-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="dcTerms-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a> --> &nbsp; Darwin Core terms</label>         
               <div class="vn-col-md-2">
                 <input id="collectioncode" class="form-control" type="text" placeholder="CollectionCode">
               </div>
@@ -227,7 +227,7 @@
           </div> 
 
         <div class="form-group">
-          <label class="col-lg-2 control-label"><a id="show-years-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="years-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Years from</label>
+          <label class="col-lg-2 control-label"><a id="show-years-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="years-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Years from </label>
           <div class="vn-col-md-2">
             <input class="form-control" type="text" id="datestart">
           </div>
@@ -239,7 +239,7 @@
           </div>
         </div>
         <div class="form-group">
-          <label class="col-lg-2 control-label"><a id="show-months-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="months-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Months from</label>
+          <label class="col-lg-2 control-label"><a id="show-months-tip" href="http://www.vertnet.org/resources/advancedsearchoptionsguide.html" target="_blank"><span id="months-tip" class="infotipDisplay"><b class="glyphicon glyphicon-info-sign infotip"></b></span></a>Months from </label>
           <div class="vn-col-md-2">
             <input class="form-control" type="text" id="monthstart">
           </div>

--- a/www/js/app/views/search.js
+++ b/www/js/app/views/search.js
@@ -396,7 +396,7 @@ define([
 		  this.$('#show-years-tip').tooltip({
 			  placement: 'top',
 			  html: 'true',
-			  title: 'Search will identify all records contained within the range of years submitted.<br><br>Read more...',
+			  title: 'Search will identify all records contained within the range of years submitted. Use four-digit format.',
 			  container: '#years-tip'
 			});
 		  this.$('#years-tip').mouseover(_.bind(function(e) {
@@ -408,7 +408,7 @@ define([
 		  this.$('#show-months-tip').tooltip({
 			  placement: 'top',
 			  html: 'true',
-			  title: 'Search will identify all records contained within the range of months submitted.<br><br>Read more...',
+			  title: 'Search will identify all records contained within the range of months submitted. Use numerical values 1 through 12.',
 			  container: '#months-tip'
 			});
 		  this.$('#months-tip').mouseover(_.bind(function(e) {
@@ -419,7 +419,7 @@ define([
 		  
 	//Get List of institutions and institutionCodes for institutionCode select
 	$.getJSON("http://vertnet.cartodb.com/api/v2/sql?q=SELECT icode, orgname, concat(icode,' - ',orgname) AS instcombo FROM resource where ipt=TRUE AND networks LIKE %27%25VertNet%25%27 GROUP BY icode, orgname ORDER BY icode, orgname",function(institutions) {
-         var listItems = '<option value="">Select institution</option>';
+         var listItems = '<option value="">Select institution code</option>';
 
 		$.each(institutions.rows, function(key, val) {
  
@@ -540,7 +540,7 @@ define([
       this.$('#sort').val(this.options.query.sort ? this.options.query.sort : "");
       setTimeout(_.bind(function() {
         if (!store.get('search-carat-closed') && !this.options.query.advanced) {
-          this.$('#search-carat').popover({placement: 'top', content: 'More search options'});
+          this.$('#search-carat').popover({placement: 'top', content: ''});
           this.$('#search-carat').popover('show');
         } 
       }, this), 2000);
@@ -928,6 +928,9 @@ define([
           this.$('#click-row-tip').show();       
         } 
         table.show();
+		$('html, body').animate({
+    		scrollTop: $('#resultTabs').offset().top
+	}, 1000);
         this.$('#bottom-pager').show();
         // this.$('#no-results').hide();
         this.$('.counter').show();


### PR DESCRIPTION
Round 3 edits.  Included:

Staggering issue with DwC fields.
Removal of most of the info bubbles in favor of placeholder help text
Scroll to results after search completes.
Fix of URLs to new tab/window from Rights tab.
Detail map sizing slightly increased.

Ready for deploy to tuco.  Will send testing email to group after deploy.